### PR TITLE
allowing insertion of non-escaped html characters via preceding backs…

### DIFF
--- a/stagit-index.c
+++ b/stagit-index.c
@@ -36,6 +36,7 @@ xmlencode(FILE *fp, const char *s, size_t len)
 
 	for (i = 0; *s && i < len; s++, i++) {
 		switch(*s) {
+		case '\\': fputc(*++s,     fp); i++; break;
 		case '<':  fputs("&lt;",   fp); break;
 		case '>':  fputs("&gt;",   fp); break;
 		case '\'': fputs("&#39;" , fp); break;

--- a/stagit.c
+++ b/stagit.c
@@ -365,6 +365,7 @@ xmlencode(FILE *fp, const char *s, size_t len)
 
 	for (i = 0; *s && i < len; s++, i++) {
 		switch(*s) {
+		case '\\': fputc(*++s,     fp); i++; break;
 		case '<':  fputs("&lt;",   fp); break;
 		case '>':  fputs("&gt;",   fp); break;
 		case '\'': fputs("&#39;",  fp); break;


### PR DESCRIPTION
…lash

I wanted the ability to have a link in my repo description, so added a case in the xmlencode function for back slash to print out the next character unencoded.

Thus `\<a href=\"https://adventofcode.com/\"\>https://adventofcode.com/\</a\>` gets rendered as a normal hyperlink.

thanks for the neat software!